### PR TITLE
Fix Qt install modules

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Set up MSVC (VS2022)
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Install Qt 6 (qtbase + qtmultimedia)
+      - name: Install Qt 6 (qtmultimedia module)
         uses: jurplel/install-qt-action@v4
         with:
           version: '6.5.3'
-          modules: 'qtbase qtmultimedia'
+          modules: 'qtmultimedia'
 
       - name: Configure CMake (MSVC generator)
         run: cmake -S . -B ${{ env.BUILD_DIR }} -G "Visual Studio 17 2022" -A x64


### PR DESCRIPTION
## Summary
- adjust the Windows workflow to request only the Qt Multimedia module when installing Qt 6.5.3
- clarify the workflow step name since qtbase is installed implicitly and cannot be requested as a module

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d16d500c44832883ac67bf8ebf718b