### PR TITLE
Fix CMake parse error

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Set up MSVC (VS2022)
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Install Qt 6 (qtbase + qtmultimedia)
+      - name: Install Qt 6 (qtmultimedia module)
         uses: jurplel/install-qt-action@v4
         with:
           version: '6.5.3'
-          modules: 'qtbase qtmultimedia'
+          modules: 'qtmultimedia'
 
       - name: Configure CMake (MSVC generator)
         run: cmake -S . -B ${{ env.BUILD_DIR }} -G "Visual Studio 17 2022" -A x64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,13 +36,10 @@ qt_add_resources(niseyuki "sfx"
 )
 
 target_include_directories(niseyuki PRIVATE src)
-
- codex/develop-native-desktop-gui-for-niseyuki-w1ymqe
 target_link_libraries(niseyuki PRIVATE
     Qt6::Widgets
     Qt6::Multimedia
 )
 
 
- main
 qt_finalize_executable(niseyuki)

--- a/src/EncodeJob.h
+++ b/src/EncodeJob.h
@@ -2,11 +2,9 @@
 
 #include <QDir>
 #include <QFileInfo>
- codex/develop-native-desktop-gui-for-niseyuki-w1ymqe
 #include <QPoint>
 #include <QSize>
 
- main
 #include <QString>
 #include <QStringList>
 #include <QVector>


### PR DESCRIPTION
## Summary
- remove stray text from CMakeLists.txt that broke parsing on Windows

## Testing
- cmake -S . -B build *(fails: Qt6 not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d16d500c44832883ac67bf8ebf718b